### PR TITLE
Add Calendar to top menu

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -40,6 +40,11 @@ name = 'Blog'
 url = '/blog/'
 weight = 60
 
+[[menus.main]]
+name = 'Calendar'
+url = 'https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week'
+weight = 70
+
 [permalinks]
   [permalinks.page]
     posts = '/blog/:slug/'


### PR DESCRIPTION
**Description:**
Add Calendar link to Hiero website menu for improved visibility.

**Related issue(s):** N/A

**Fixes # (If there's a specific issue number, add it here)**

**Notes for reviewer:**
This change was suggested during the community call on April 17, 2025, to address user feedback about difficulty finding the public calendar. The Calendar page already exists but was not easily discoverable through the main navigation.

**Checklist**

N/A - Documented (Code comments, README, etc.)
N/A - Tested (unit, integration, etc.)