### PR TITLE
feat: replace open source tab with good first issue query tab to …

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -25,8 +25,8 @@ pageRef = '/'
 weight = 10
 
 [[menus.main]]
-name = 'Open Source'
-url = '/#open-source'
+name = 'Good First Issues'
+url = 'https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Ahiero-ledger+archived%3Afalse+label%3A%22good+first+issue%22+'
 weight = 20
 
 [[menus.main]]


### PR DESCRIPTION
# Description
Adds a basic good first issue finder on the hiero website and collect data on interest

## Changes Made
- Added a link to github hiero good first issue query
- Swap open source tab for good first issue tab

NOTE
users will have to be logged in to github else will see a 404 error

## Related Issues 
Closes #108
