### PR TITLE
chore: removed calendar link from cards

### DIFF
--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -156,11 +156,6 @@
           <p class="text-sm mb-4 text-gray-600"><strong>Schedule:</strong> {{ .schedule | safeHTML }}</p>
           {{ end }}
           <div class="flex flex-col gap-2 mt-4">
-            {{ if .calendar_link }}
-            <a href="{{ .calendar_link }}" target="_blank" rel="noreferrer noopener" class="text-red hover:text-red-dark text-base font-medium underline">
-              View Calendar →
-            </a>
-            {{ end }}
             {{ if .register_link }}
             <a href="{{ .register_link }}" target="_blank" rel="noreferrer noopener" class="text-red hover:text-red-dark text-base font-medium underline">
               Register →


### PR DESCRIPTION
# Description
<!-- Explain the purpose of this PR -->
Removed  View Calendar → anchor rendered inside each section_meet_calls block.

Current Behavior

Each meeting card shows:

Description
Schedule
View Calendar →
Register →

Each meeting card should show:

Description
Schedule
Register →

## Changes Made
- [x] Added...
- [x] Modified...
- [x] Fixed...

## Related Issues
<!-- Example: Fixes #123, Closes #456 -->
Fixes  #127 
Closes #127 

## Screenshots (if applicable)
<!-- Before/after screenshots, UI changes, etc. -->

Before

<img width="1617" height="802" alt="image" src="https://github.com/user-attachments/assets/480a7f4b-287e-4e90-917b-1a279e8e36b0" />


After

<img width="1637" height="968" alt="image" src="https://github.com/user-attachments/assets/7905d10f-4ded-42f9-af74-e7110679fbb4" />

