### PR TITLE
Fix: Update README blog post example link to view mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ hugo server --buildDrafts
 
 Learn about [draft](https://gohugo.io/getting-started/usage/#draft-future-and-expired-content)
 
-See an example [Blog Post](https://github.com/hiero-ledger/hiero-website/edit/main/content/posts/python-v0.1.7-release.md)
+See an example [Blog Post](https://github.com/hiero-ledger/hiero-website/blob/main/content/posts/python-v0.1.7-release.md)
 
 See [Detailed Guide on Creating a Blog Post](./docs/blogs.md)
 


### PR DESCRIPTION
## Description
Updated the blog post example link in README.md from edit mode (`/edit/`) to view mode (`/blob/`) so users can view the example without accidentally editing it.

## Changes Made
- Line 76: Changed `/edit/main/` to `/blob/main/` in the blog post example link

## Related Issue
Fixes #133

## Checklist
- [x] Issue requirements addressed
- [x] Commit signed off with DCO
- [x] Changes are minimal and focused