### PR TITLE
Fix broken link in 02_good_first_issue.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
@@ -60,7 +60,8 @@ body:
         > - Work spanning multiple subsystems or requiring deep design knowledge
         >
         > 📖 *For a more detailed explanation, refer to:  
-        > [`.github/guidelines_good_first_issues.md`](.github/guidelines_good_first_issues.md).*
+        > [`.github/maintainers/guidelines_good_first_issues.md`](.github/maintainers/guidelines_good_first_issues.md).*
+
 
   - type: textarea
     id: issue


### PR DESCRIPTION
Fixed the broken link in `.github/ISSUE_TEMPLATE/02_good_first_issue.yml` by updating it to the correct path under `.github/maintainers/`.

Closes #141
