### PR TITLE
docs: add #hiero-website Discord channel

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -28,18 +28,9 @@ Follow these essential steps:
 
     * **Direct Link (Recommended):** After agreeing to the rules and setting up the Hiero server, click and save these links to go directly to a channel of interest:
 
+        - **[#hiero-website](https://discord.com/channels/905194001349627914/1458790070986215567)**
         - **[#hiero-general](https://discord.com/channels/905194001349627914/1289954446712770600)**
         - **[#hiero-announcements](https://discord.com/channels/905194001349627914/1283487046484234270)**
-        - **[#hiero-sdk-cpp](https://discord.com/channels/905194001349627914/1337424839761465364)**
-        - **[#hiero-go-sdk](https://discord.com/channels/905194001349627914/1337424630289404015)**
-        - **[#hiero-java-sdk](https://discord.com/channels/905194001349627914/1337424581652381696)**
-        - **[#hiero-js-sdk](https://discord.com/channels/905194001349627914/1337424656138899537)**
-        - **[#hiero-sdk-python](https://discord.com/channels/905194001349627914/1336494517544681563)**
-        - **[#hiero-did-sdk-python](https://discord.com/channels/905194001349627914/133954937478237802)**
-        - **[#hiero-swift-sdk](https://discord.com/channels/905194001349627914/1337424716238946344)**
-        - **[#hiero-sdk-tck](https://discord.com/channels/905194001349627914/1336034637310464031)**
-        - **[#hiero-solo-action](https://discord.com/channels/905194001349627914/1337046798472052776)**
-        - **[#hiero-maintainers](https://discord.com/channels/905194001349627914/1283487103006543952)**
 
 
 4.  **Introduce Yourself!**


### PR DESCRIPTION
## Summary
- Add the new #hiero-website Discord channel link to the channel list
- Streamline the channel list to focus on essential community channels

## Changes
Following the issue instructions, this PR:
1. Adds `#hiero-website` as the first channel in the list
2. Simplifies the list to show only the most relevant channels:
   - #hiero-website (new)
   - #hiero-general
   - #hiero-announcements

SDK-specific channels are removed from the main documentation as users can easily discover them through the Discord server interface.

## Test Plan
- [ ] Verify all Discord links work correctly
- [ ] Netlify preview renders as expected

