### PR TITLE
Remove Roadmap tab from navigation menu

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -42,11 +42,6 @@ url = '/#connect'
 weight = 40
 
 [[menus.main]]
-name = 'Roadmap'
-url = '/#roadmap'
-weight = 50
-
-[[menus.main]]
 name = 'Blog'
 url = '/blog/'
 weight = 60


### PR DESCRIPTION
#remove the roadmap tab

Removed the Roadmap menu entry from hugo.toml since the roadmap section was deleted from the website.

Fixes #195 

