### PR TITLE
docs: add Linux setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [docs/hugo-setup.md](docs/hugo-setup.md) for installing prerequisites (Hugo,
 ```
 npm i 
 ```
-
+For Linux Setup Instructions [linux_setup.md](docs/setup/linux_setup.md)
 For Windows Setup Instructions [Windows_setup.md](docs/setup/windows_setup.md)
 For Windows Setup Instructions [Macbook_setup.md](docs/setup/Macbook_setup.md)
 ## Environments

--- a/docs/setup/linux_setup.md
+++ b/docs/setup/linux_setup.md
@@ -1,0 +1,47 @@
+# Linux Setup
+
+This guide explains how to set up the Hiero website locally on a Linux system.
+
+## Step 1: Install Dependencies
+
+Install Git, Node.js, npm, and Hugo (extended).
+
+    sudo apt update
+    sudo apt install git nodejs npm -y
+    sudo snap install hugo --channel=extended
+
+## Step 2: Clone the Repository
+
+Clone the repository and navigate into it:
+
+    git clone https://github.com/hiero-ledger/hiero-website.git
+    cd hiero-website
+
+## Step 3: Install Node Packages
+
+Install required npm dependencies:
+
+    npm install
+
+## Step 4: Local Development
+
+Start the Hugo development server with live reloading:
+
+    npm run start
+
+Open your browser and visit:
+
+    http://localhost:1313/
+
+## Step 5: Preview Draft Content
+
+To preview draft blog posts:
+
+    hugo server --buildDrafts
+
+## Step 6: Build for Production
+
+To generate a production-ready build:
+
+    npm run build
+


### PR DESCRIPTION
## What this PR does
This PR adds a Linux setup guide for running the Hiero website locally.

Closes (#155)