### PR TITLE
docs: fix typo "Pleae" to "Please" in workflow.md

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -294,7 +294,7 @@ Set it to draft or 'ready to review' status and submit!
 4. Wait for Checks
 We have several security and quality checks.
 
-Pleae review them, view any previews, and check they all pass.
+Please review them, view any previews, and check they all pass.
 
 If they are failing and you require help, you can:
 - Contact us on [discord](discord.md)


### PR DESCRIPTION
Description
This PR fixes a small spelling mistake in the contribution workflow document on line 297.

Changes Made

Corrected "Pleae" to "Please".

Related Issues
Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling errors in workflow documentation
  * Enhanced workflow guidance with additional support resources and help options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->