### PR TITLE
Change duplicated Windows setup to MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm i
 ```
 For Linux Setup Instructions [linux_setup.md](docs/setup/linux_setup.md)
 For Windows Setup Instructions [Windows_setup.md](docs/setup/windows_setup.md)
-For Windows Setup Instructions [Macbook_setup.md](docs/setup/Macbook_setup.md)
+For MacOS Setup Instructions [Macbook_setup.md](docs/setup/Macbook_setup.md)
 ## Environments
 
 ### Dev


### PR DESCRIPTION
Corrected the label for MacOS setup instructions in README. Fixes #224 