### PR TITLE
docs: fix typo 'Pleae' → 'Please' in workflow.md

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -294,7 +294,7 @@ Set it to draft or 'ready to review' status and submit!
 4. Wait for Checks
 We have several security and quality checks.
 
-Pleae review them, view any previews, and check they all pass.
+Please review them, view any previews, and check they all pass.
 
 If they are failing and you require help, you can:
 - Contact us on [discord](discord.md)


### PR DESCRIPTION
Fixes #221

Small typo fix: 'Pleae' → 'Please' on line 297 of `docs/workflow.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typographical error in workflow documentation
  * Expanded available support channels for pull request reviews, now including community calls and direct pull request assistance options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->