### PR TITLE
docs: fix typo 'Commmits' → 'Commits' in workflow.md

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -175,7 +175,7 @@ This is incorrect:
 git commit -S -s -m "looks like its mostly working now"
 ```
 
-Read about conventional commit messages here: [Conventional Commmits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+Read about conventional commit messages here: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 
 ## DCO and GPG Signing Commits
 **Each** commit in a pull request needs to be:


### PR DESCRIPTION
Fixes #222

Small typo fix: 'Conventional Commmits' → 'Conventional Commits' on line 178 of `docs/workflow.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typographical error in the Conventional Commit messages reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->