### PR TITLE
Fix typo: Pleae -> Please in workflow.md

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -294,7 +294,7 @@ Set it to draft or 'ready to review' status and submit!
 4. Wait for Checks
 We have several security and quality checks.
 
-Pleae review them, view any previews, and check they all pass.
+Please review them, view any previews, and check they all pass.
 
 If they are failing and you require help, you can:
 - Contact us on [discord](discord.md)


### PR DESCRIPTION
## Description

Fixes a typo in the contribution workflow documentation.

Line 297: "Pleae review them..." -> "Please review them..."

## Issue

This PR addresses the Good First Issue: https://github.com/hiero-ledger/hiero-website/issues/221

## Changes

- Fixed typo: "Pleae" -> "Please" in docs/workflow.md (line 297)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typographical error in the workflow documentation section to improve overall clarity and maintain professional standards.
  * Expanded the "Wait for Checks" section with additional helpful resources for users, including direct links to community call scheduling information and practical guidance for requesting assistance on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->