### PR TITLE
fix: correct typo Pleae to Please in workflow documentation

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -294,7 +294,7 @@ Set it to draft or 'ready to review' status and submit!
 4. Wait for Checks
 We have several security and quality checks.
 
-Pleae review them, view any previews, and check they all pass.
+Please review them, view any previews, and check they all pass.
 
 If they are failing and you require help, you can:
 - Contact us on [discord](discord.md)


### PR DESCRIPTION
Fixes #221

Corrected typo in docs/workflow.md line 297: "Pleae" -> "Please"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in workflow documentation.
  * Enhanced post-check guidance with expanded resources, including links to community calls and additional support channels for contributors seeking assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->