### PR TITLE
Add repo to good first issue link in hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -23,7 +23,7 @@ target = 'static/images'
 
 [[menus.main]]
 name = 'Good First Issues'
-url = 'https://github.com/issues?q=is%3Aopen%20is%3Aissue%20org%3Ahiero-ledger%20archived%3Afalse%20no%3Aassignee%20(label%3A%22good%20first%20issue%22%20OR%20label%3A%22skill%3A%20good%20first%20issue%22)%20(repo%3Ahiero-ledger%2Fhiero-sdk-cpp%20OR%20repo%3Ahiero-ledger%2Fhiero-sdk-swift%20OR%20repo%3Ahiero-ledger%2Fhiero-sdk-python%20OR%20repo%3Ahiero-ledger%2Fhiero-website)'
+url = 'https://github.com/issues?q=is%3Aopen%20is%3Aissue%20org%3Ahiero-ledger%20archived%3Afalse%20no%3Aassignee%20(label%3A%22good%20first%20issue%22%20OR%20label%3A%22skill%3A%20good%20first%20issue%22)%20(repo%3Ahiero-ledger%2Fhiero-sdk-cpp%20OR%20repo%3Ahiero-ledger%2Fhiero-sdk-swift%20OR%20repo%3Ahiero-ledger%2Fhiero-sdk-python%20OR%20repo%3Ahiero-ledger%2Fhiero-sdk-js%20OR%20repo%3Ahiero-ledger%2Fhiero-website)'
 weight = 20
 
 [[menus.main]]


### PR DESCRIPTION
# Description
This PR adds a repo:hiero-ledger/hiero-sdk-js link to the Good First Issue link on hiero.org.

Fixes: #243 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the "Good First Issues" navigation menu entry to include the hiero-sdk-js repository in its search parameters, enabling users to discover more beginner-friendly contribution opportunities across the expanded project scope.
  * Optimized the menu item's display priority for improved visibility and accessibility within the main navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->