### PR TITLE
docs: Delete the Contribute tab from hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -27,11 +27,6 @@ url = 'https://github.com/issues?q=is%3Aopen%20is%3Aissue%20org%3Ahiero-ledger%2
 weight = 20
 
 [[menus.main]]
-name = 'Contribute'
-url = '/#contribute'
-weight = 30
-
-[[menus.main]]
 name = 'Connect'
 url = '/#connect'
 weight = 40


### PR DESCRIPTION
# Description
This PR removed the Contribute tab from hugo.toml

## Related Issues
Fixes: #255 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the "Contribute" entry from the main navigation menu.
  * No other navigation entries were changed; the rest of the menu structure remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->