### PR TITLE
docs: Delete Repositories tab from hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -27,6 +27,11 @@ url = 'https://github.com/issues?q=is%3Aopen%20is%3Aissue%20org%3Ahiero-ledger%2
 weight = 20
 
 [[menus.main]]
+name = 'Contribute'
+url = '/#contribute'
+weight = 30
+
+[[menus.main]]
 name = 'Connect'
 url = '/#connect'
 weight = 40


### PR DESCRIPTION
# Description
This PR removes the Repositories tab from hugo.toml

## Related Issues
Fixes: #256 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the "Repositories" item from the main navigation menu.
  * Other top-level navigation items (Good First Issues, Contribute, Connect, Blog, Calendar) remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->