### PR TITLE
fix: format footer link as hyperlink issue#314

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import Container from "@/components/Container";
 
 export default function Footer() {
   return (
-    <div className="bg-black text-base text-white-dark text-center py-8">
+    <div className="bg-black py-8 text-center text-base text-white-dark">
       <Container>
         <p>
           Copyright © Hiero a Series of LF Projects, LLC | For web site terms of
@@ -12,7 +12,7 @@ export default function Footer() {
             target="_blank"
             rel="noreferrer noopener"
             className="text-white underline hover:text-white">
-            https://lfprojects.org
+            LF Projects
           </a>
           .
         </p>


### PR DESCRIPTION
This PR fixes issue #314 by converting the raw LF link in the footer into a hyperlink.
<img width="2368" height="120" alt="Screenshot 2026-03-27 174107" src="https://github.com/user-attachments/assets/d65792e2-e9c7-49c6-ac65-eb71d68d3f5b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Footer link now displays a user-friendly label ("LF Projects") instead of the full URL for improved readability.
  * Minor markup and formatting tweaks to the footer for cleaner structure and more consistent presentation across the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->