### PR TITLE
docs: make sections briefer

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -15,7 +15,7 @@ section_why_open_source_text = "The goal of Hiero is to build a diverse communit
 
 section_what_parts_open_source_heading = "What parts of Hiero are Open Source?"
 section_what_parts_open_source_text = '''
-Hiero is fully open source. While its transition to Linux Foundation Decentralized Trust continues, additional contributions are available in <a href="https://github.com/hashgraph" target="_blank" rel="noreferrer noopener">Hedera’s GitHub organization</a>. The technical steering committee (TSC) of Hiero will initially oversee adding projects needed for an enterprise-ready decentralized network to a new Hiero Github organization. See the roadmap for more details.
+Hiero is fully open source. While its transition to Linux Foundation Decentralized Trust continues, additional contributions are available in <a href="https://github.com/hashgraph" target="_blank" rel="noreferrer noopener">Hedera’s GitHub organization</a>. The technical steering committee (TSC) of Hiero will initially oversee adding projects needed for an enterprise-ready decentralized network to a new Hiero GitHub organization. See the roadmap for more details.
 '''
 
 section_technical_steering_committee_heading = "The Technical Steering Committee of Hiero"


### PR DESCRIPTION
# Description
This PR makes open source related sections briefer.

## Related Issues
Fixes: #311 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated homepage copy to reposition the "Why is Hiero Open Source?" message, now addressing a community of "developers and innovators" and reframing accessibility rationale.
  * Refined "What parts of Hiero are Open Source?" wording to state the project is "fully open source," shortened transition text, and clarified initial oversight language and roadmap link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->