### PR TITLE
fix: move "Jump to Open Issues" section above Community Calls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -378,14 +378,14 @@ export default function Home() {
     <>
       <HeroSection data={heroData} />
       <WhatIsHieroSection data={whatIsHieroData} />
-      <Divider /> 
+      <Divider />
       <IssueJumpSection data={issueJumpData} />
       <Divider />
       <MeetSection data={meetData} />
       <Divider />
       <ReposCarousel data={reposData} />
       <Divider />
-     
+
       <OpenSourceSection data={openSourceData} />
       <Divider />
       <QuotesCarousel data={quotesData} />


### PR DESCRIPTION
## Description
This PR rearranges the homepage sections by moving the "Jump to Open Issues" section above the "Join our Hiero Community Calls" section.

## Changes Made
- [x] Moved IssueJumpSection above MeetSection in `page.tsx`
- [x] Removed unnecessary `package-lock.json` file
- [x] Signed commits to comply with DCO requirements

## Related Issues
Closes #312

## Screenshots
Not applicable (UI section reordering only)

## Checklist
- [x] Code runs locally without errors
- [x] Changes are minimal and focused
- [x] No unrelated files included
- [x] Commit is signed (`Signed-off-by`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Repositioned the Issue Jump section to appear immediately after the "What is Hiero" section.
  * Adjusted surrounding separators so the page flow is consistent and a duplicate Issue Jump block was removed, resulting in a smoother transition from the repositories carousel to the Open Source section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->