### PR TITLE
chore: secure pr title check permissions and upgrade action

### DIFF
--- a/.github/workflows/pr-formatting.yaml
+++ b/.github/workflows/pr-formatting.yaml
@@ -14,8 +14,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: read
-  statuses: write
+  pull-requests: read
 
 concurrency:
   group: pr-formatting-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -32,6 +31,6 @@ jobs:
           egress-policy: audit
 
       - name: Check PR Title
-        uses: step-security/conventional-pr-title-action@bb2263ec311ca158e9ffa6bd9b997fb425402034 # v3.2.6
+        uses: step-security/action-semantic-pull-request@bc0cf74f5be4ce34accdec1ae908dff38dc5def1 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
This PR refactors the PR Formatting workflow to adopt tighter security constraints per the principle of least privilege, specifically addressing finding in issue #266. It maintains `pull_request_target` so that fork PR metadata is still reliably readable, but drastically minimizes the risk footprint by reducing the injected token permissions and utilizing the maintained, secure replacement action.

## Changes Made
- [x] Modified `.github/workflows/pr-formatting.yaml` to restrict permissions strictly to `pull-requests: read` instead of requiring write access.
- [x] Fixed potential security risks by replacing the deprecated title check action with the actively maintained `step-security/action-semantic-pull-request@v6.1.1` 

## Related Issues
Fixes #266

## Checklist
- [x] Linting passes
- [x] Branch up-to-date with main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the internal pull request validation workflow: swapped the PR title check action, adjusted workflow permissions for PR validation, and streamlined the validation step.

---

**Note:** This release contains no user-facing changes; updates are limited to development infrastructure and process improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->