### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/components/IssueList/__tests__/IssueList.test.tsx
+++ b/src/components/IssueList/__tests__/IssueList.test.tsx
@@ -81,9 +81,18 @@ describe("IssueList", () => {
 
     const issueLinks = screen
       .getAllByRole("link")
-      .filter(link =>
-        link.getAttribute("href")?.startsWith("https://issues.example"),
-      );
+      .filter(link => {
+        const href = link.getAttribute("href");
+        if (!href) {
+          return false;
+        }
+        try {
+          const url = new URL(href);
+          return url.protocol === "https:" && url.hostname === "issues.example";
+        } catch {
+          return false;
+        }
+      });
 
     expect(issueLinks.map(link => link.textContent)).toEqual([
       "Go issue",


### PR DESCRIPTION
Potential fix for [https://github.com/hiero-ledger/hiero-website/security/code-scanning/4](https://github.com/hiero-ledger/hiero-website/security/code-scanning/4)

In general, the problem should be fixed by parsing the URL and checking its `host` (and optionally its scheme) against an explicit whitelist, instead of relying on string prefix checks on the entire URL. This avoids cases where a malicious host embeds the expected domain as part of a longer hostname or uses user-info tricks.

In this specific test, the intent is clearly to select only links whose host is `issues.example`. We can do this without changing visible behavior by:

- Getting the `href` attribute as a string.
- Constructing a `URL` object from it (using the built-in `URL` class, which is available in jsdom/Vitest environments).
- Filtering links by checking `url.hostname === "issues.example"` and `url.protocol === "https:"`.

No changes are needed to the imports; we can rely on the global `URL` class in the test environment. The only code change is within `src/components/IssueList/__tests__/IssueList.test.tsx` at the `issueLinks` computation around lines 82–86.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
