### PR TITLE
fix(tsc): align Read full profile buttons at bottom of member cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Fixed
+
+- Fix alignment of "Read full profile" buttons on TSC page: cards now use a flex-column layout so the button is consistently pinned to the bottom regardless of bio length.

--- a/src/app/tsc/page.tsx
+++ b/src/app/tsc/page.tsx
@@ -226,7 +226,7 @@ export default function TSCSection() {
                           lastFocusedTriggerIdRef.current = `tsc-read-profile-${index}`;
                           setSelectedMember(member);
                         }}
-                        className="mt-4 inline-flex items-center rounded-full border-2 border-white-dark px-4 py-1.5 text-sm font-medium text-charcoal transition-colors hover:border-red focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-light focus-visible:ring-offset-2"
+                        className="mt-4 inline-flex items-center justify-center rounded-full border-2 border-white-dark px-4 py-1.5 text-sm font-medium text-charcoal transition-colors hover:border-red focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-light focus-visible:ring-offset-2"
                         aria-label={`Read full profile for ${fullName}`}>
                         Read full profile
                       </button>

--- a/src/app/tsc/page.tsx
+++ b/src/app/tsc/page.tsx
@@ -177,7 +177,7 @@ export default function TSCSection() {
               return (
                 <article
                   key={`${fullName}-${index}`}
-                  className="h-full rounded-2xl border-2 border-white-dark bg-white p-6 sm:p-7">
+                  className="flex flex-col h-full rounded-2xl border-2 border-white-dark bg-white p-6 sm:p-7">
                   {member.photo ? (
                     <Image
                       src={`/images/tsc/${member.photo}`}
@@ -194,7 +194,7 @@ export default function TSCSection() {
                     />
                   )}
 
-                  <div className="mt-5">
+                  <div className="flex flex-1 flex-col mt-5">
                     <h3 className="text-xl sm:text-2xl mb-2">{fullName}</h3>
 
                     {member.gitHubAccount ? (
@@ -214,7 +214,9 @@ export default function TSCSection() {
                       </a>
                     ) : null}
 
-                    <p className="mt-4 text-base text-gray">{bioPreview}</p>
+                    <p className="grow mt-4 text-base text-gray">
+                      {bioPreview}
+                    </p>
 
                     {hasBio ? (
                       <button


### PR DESCRIPTION
# Description
Fixes inconsistent alignment of the **"Read full profile"** buttons on the TSC page by applying a flex column layout to member cards, ensuring buttons stay pinned to the bottom regardless of bio length.

## Changes Made
- [x] Applied `flex flex-col` to TSC member card container (`<article>`)
- [x] Updated content wrapper to `flex flex-1 flex-col`
- [x] Added `grow` to bio paragraph to push button to bottom
- [x] Added changelog entry for the fix

## Related Issues
Fixes #380

## Screenshots 
**Before:**
Buttons appeared at inconsistent vertical positions across cards due to varying bio lengths.
<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/e1ba6536-8f65-4af6-8041-7e30e4d269b9" />
**After**
Buttons are consistently aligned at the bottom of each card using a flex column layout.
<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/102bef6e-3667-422d-a2f5-7f41f17507d9" />


## Checklist
- [ ] Tests added/updated
- [x] Documentation updated
- [x] Linting passes
- [x] Branch up-to-date with main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alignment of "Read full profile" buttons on the TSC page so they remain pinned to the bottom of member cards regardless of bio length.
* **Documentation**
  * Added an initial changelog entry noting the TSC page fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->