### PR TITLE
fix: removed open source text inside TSC

### DIFF
--- a/src/app/tsc/page.tsx
+++ b/src/app/tsc/page.tsx
@@ -264,9 +264,6 @@ export default function TSCSection() {
                 <p className="text-base text-gray grow">
                   {resource.description}
                 </p>
-                <span className="mt-5 text-base font-medium text-red underline">
-                  Open resource
-                </span>
               </a>
             ))}
           </div>


### PR DESCRIPTION
# Description
This PR fixes the inconsistency in the TSC page by removing highlighted open resource text. Now, the box sections behave consistently across the website, where navigation happens by clicking the entire box instead of visible hyperlinks.

## Changes Made
- [x] Removed open resource URLs from the TSC page
- [x] Modified src/app/tsc by deleting 3  lines
- [x] Fixed and Ensured consistency with other box sections across the website

## Related Issues
Fixes #382 

## Screenshots (if applicable)
<img width="1761" height="622" alt="Screenshot from 2026-04-13 19-13-13" src="https://github.com/user-attachments/assets/32a0237d-fca7-481b-be42-4ffe921ee64e" />


## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [x] Linting passes
- [x] Branch up-to-date with main

## Deployment Notes
<!-- Special instructions for deployment? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the "Open resource" call-to-action text from governance resource cards for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->