### PR TITLE
fix: resolve SVG image aspect-ratio warnings

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -49,8 +49,9 @@ export default function NotFound() {
               <Image
                 src="/images/Hiero-Icon.svg"
                 alt="Hiero"
-                width={40}
-                height={40}
+                width={68}
+                height={67}
+                className="w-10 h-auto shrink-0"
               />
               <p className="text-lg font-medium">Try one of these paths</p>
             </div>

--- a/src/components/Divider/__tests__/__snapshots__/Divider.test.tsx.snap
+++ b/src/components/Divider/__tests__/__snapshots__/Divider.test.tsx.snap
@@ -6,10 +6,11 @@ exports[`Divider > renders the Hiero divider icon 1`] = `
 >
   <img
     alt=""
-    height="40"
+    class="w-10 h-auto shrink-0"
+    height="67"
     loading="lazy"
     src="/images/Hiero-Icon.svg"
-    width="40"
+    width="68"
   />
   <div
     class="w-full bg-white-dark h-[1px]"

--- a/src/components/Divider/index.tsx
+++ b/src/components/Divider/index.tsx
@@ -6,8 +6,9 @@ export default function Divider() {
       <Image
         src="/images/Hiero-Icon.svg"
         alt=""
-        width={40}
-        height={40}
+        width={68}
+        height={67}
+        className="w-10 h-auto shrink-0"
         loading="lazy"
       />
       <div className="w-full bg-white-dark h-[1px]" />

--- a/src/components/WhatIsHieroSection/__tests__/__snapshots__/WhatIsHieroSection.test.tsx.snap
+++ b/src/components/WhatIsHieroSection/__tests__/__snapshots__/WhatIsHieroSection.test.tsx.snap
@@ -41,10 +41,11 @@ exports[`WhatIsHieroSection > renders the intro and supporting points 1`] = `
           >
             <img
               alt=""
-              height="55"
+              class="w-[55px] h-auto shrink-0"
+              height="57"
               loading="lazy"
               src="/images/icon-1.svg"
-              width="55"
+              width="56"
             />
             <div>
               <h3
@@ -67,10 +68,11 @@ exports[`WhatIsHieroSection > renders the intro and supporting points 1`] = `
           >
             <img
               alt=""
-              height="55"
+              class="w-[55px] h-auto shrink-0"
+              height="57"
               loading="lazy"
               src="/images/icon-2.svg"
-              width="55"
+              width="56"
             />
             <div>
               <h3

--- a/src/components/WhatIsHieroSection/index.tsx
+++ b/src/components/WhatIsHieroSection/index.tsx
@@ -46,8 +46,9 @@ export default function WhatIsHieroSection({ data }: WhatIsHieroSectionProps) {
                 <Image
                   src={point.icon}
                   alt=""
-                  width={55}
-                  height={55}
+                  width={56}
+                  height={57}
+                  className="w-[55px] h-auto shrink-0"
                   loading="lazy"
                 />
                 <div>


### PR DESCRIPTION
## Summary

Fixes the `next/image` aspect-ratio warnings for the affected local Hiero SVG icons by updating their sizing to respect each asset's intrinsic aspect ratio while preserving the intended rendered size.

Closes #388

## What changed

- updated the affected SVG `next/image` usages in the homepage and 404 page
- preserved the intended visual size while allowing height to follow the SVGs' intrinsic ratio
- updated the related snapshots for the changed rendered output

## Verified

- the homepage "What is Hiero?" section still renders correctly
- the 404 page card and Hiero icon still render correctly
- local checks passed:
  - `pnpm format:check`
  - `pnpm lint`
  - `pnpm test`
  - `pnpm build`

## Screenshots

### Homepage after fix
"What is Hiero?" section renders correctly with the updated SVG icon sizing.

<img width="1509" height="899" alt="homepage-after-fix" src="https://github.com/user-attachments/assets/12654067-3b6a-4aad-be1f-13209879c8ce" />



### 404 page after fix
The Hiero icon and recovery card render correctly with the updated SVG sizing.

<img width="1509" height="899" alt="404-after-fix" src="https://github.com/user-attachments/assets/5d0f71a3-a8f6-4d4e-99e6-0c0505f3e258" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icon sizing and layout styling across multiple components for improved visual consistency and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->