### PR TITLE
docs: fix broken links in blogs guide

### DIFF
--- a/docs/blogs.md
+++ b/docs/blogs.md
@@ -223,7 +223,7 @@ Before your PR is ready:
 
 - Current example post: `content/posts/hiero-enterprise-java.md`
 - Blog index metadata: `content/posts/_index.md`
-- Contributor docs index: [README.md](./README.md)
-- Local setup guide: [nextjs-setup.md](./nextjs-setup.md)
+- Contributor docs index: [README.md](../README.md)
+- Local setup guide: [Getting Started](../README.md#getting-started)
 - Repo overview: [01-repo-overview.md](./01-repo-overview.md)
 - Workflow guide: [workflow.md](./workflow.md)


### PR DESCRIPTION
# Description
Fixes broken links in `docs/blogs.md` by updating them to valid documentation targets.

## Changes Made
- [x] Updated the contributor docs index link
- [x] Updated the local setup guide link

## Related Issues
Fixes #400

## Screenshots (if applicable)
Not applicable.

## Checklist
- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Linting passes
- [x] Branch up-to-date with main

## Deployment Notes
No special deployment steps required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed internal documentation links to enhance navigation. Updated references to the contributor documentation index and setup guides to ensure users can easily discover related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->