### PR TITLE
chore: add missing docs/discord.md to fix broken links

### DIFF
--- a/docs/discord.md
+++ b/docs/discord.md
@@ -1,0 +1,68 @@
+# Getting Featured On Hiero
+
+This guide explains how to get your contributions featured in Hiero's
+weekly "Links of the Week" blog posts on [hiero.org/blog](https://hiero.org/blog).
+
+## What Is Links Of The Week
+
+Every week, the Hiero team publishes a blog post highlighting notable
+contributions, projects, and events from the community. Being featured is
+a great way to get visibility for your work and inspire other contributors.
+
+## What Can Be Featured
+
+The following types of work are eligible for featuring:
+
+- Blog posts and technical write-ups related to Hiero
+- Open-source projects built on or integrated with Hiero
+- Merged pull requests and significant code contributions
+- Community events, meetups, and conference talks
+- Documentation improvements and developer tooling
+- Tutorials, guides, and educational content
+
+## How To Submit Your Work
+
+To submit your work for featuring, follow these steps:
+
+1. **Join the LFDT Discord server** using the invite link below
+2. **Navigate to the `#hiero-website` channel**
+3. **Post a message** with the following information:
+   - A short description of your contribution
+   - A link to the relevant pull request, repository, or resource
+   - Your name or GitHub handle as you would like it to appear
+
+### Useful Discord Links
+
+- **LFDT Discord invite:** [https://discord.gg/hyperledger](https://discord.gg/hyperledger)
+- **#hiero-website channel:** [https://discord.com/channels/905194001349627914/1458790070986215567](https://discord.com/channels/905194001349627914/1458790070986215567)
+- **#hiero-general channel:** [https://discord.com/channels/905194001349627914/1289954446712770600](https://discord.com/channels/905194001349627914/1289954446712770600)
+
+## Joining The Hiero Discord
+
+If you are new to Discord, follow these steps to join:
+
+1. **Create a Discord account** at [discord.com](https://discord.com) if
+   you do not already have one
+2. **Join the LFDT server** by clicking the invite link:
+   [https://discord.gg/hyperledger](https://discord.gg/hyperledger)
+3. **Agree to the server rules** in the `#welcome` or `#rules` channel
+   to unlock full access
+4. **Select Hiero** during the server setup when prompted to choose
+   which project chats you are interested in
+
+Once you have access, navigate to the `#hiero-website` channel and
+introduce yourself.
+
+## Submission Guidelines
+
+To help the team process your submission:
+
+- Submit your work **before the end of the week** to be included in the
+  next Links of the Week post
+- Include a **direct link** to your contribution so the team can verify it
+- Keep descriptions **concise and factual**
+- Make sure your contribution is **publicly accessible**
+
+## Related Guides
+
+- [blogs.md](./blogs.md)


### PR DESCRIPTION
# Description

restores the missing `docs/discord.md` file that was accidentally removed in PR #356. This file is referenced by 19 blog posts and the `README.md`, all of which link to `docs/discord.md` on GitHub. Without this file, those links were broken.


## Changes Made
- [x] added `docs/discord.md` with contributor guidance for getting featured on Hiero

## Related Issues

Fixes #472 

## Deployment Notes

no special deployment steps and this is a standalone markdown file that does not affect the Next.js build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a contributor guide for getting featured in Hiero's weekly "Links of the Week" posts, including Discord submission instructions, channel information, and guidelines for contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->