### PR TITLE
feat: Add Coderabbit Planning

### DIFF
--- a/.github/scripts/coderabbit_plan_trigger.cjs
+++ b/.github/scripts/coderabbit_plan_trigger.cjs
@@ -1,0 +1,140 @@
+// Script to trigger CodeRabbit plan for beginner, intermediate, and advanced issues.
+
+const CODERABBIT_MARKER = '<!-- CodeRabbit Plan Trigger -->';
+
+async function triggerCodeRabbitPlan(
+  github,
+  owner,
+  repo,
+  issue,
+  marker = CODERABBIT_MARKER,
+  isDryRun = false,
+) {
+  const comment = `${marker} @coderabbitai plan`;
+
+  if (isDryRun) {
+    console.log(`[DRY RUN] Would trigger CodeRabbit plan for issue #${issue.number}`);
+    return true;
+  }
+
+  try {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issue.number,
+      body: comment,
+    });
+    console.log(`Triggered CodeRabbit plan for issue #${issue.number}`);
+    return true;
+  } catch (commentErr) {
+    console.log('Failed to trigger CodeRabbit plan:', {
+      message: commentErr?.message,
+      status: commentErr?.status,
+      owner,
+      repo,
+      issueNumber: issue?.number,
+    });
+    return false;
+  }
+}
+
+function hasBeginnerOrHigherLabel(issue, label) {
+  // Check if issue has beginner, intermediate, or advanced label (case-insensitive).
+  const allowed = ['beginner', 'intermediate', 'advanced'];
+
+  const hasAllowedLabel = issue.labels?.some((l) => allowed.includes(l?.name?.toLowerCase()));
+
+  // Also check if newly added label is beginner/intermediate/advanced.
+  const isNewLabelAllowed = allowed.includes(label?.name?.toLowerCase());
+
+  return hasAllowedLabel || isNewLabelAllowed;
+}
+
+async function hasExistingCodeRabbitPlan(github, owner, repo, issueNumber) {
+  // Check for existing CodeRabbit plan comment (limited to first 500 comments).
+  // Uses marker-based detection to avoid false positives from quoted text.
+  try {
+    const comments = [];
+    const iterator = github.paginate.iterator(github.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: issueNumber,
+      per_page: 100,
+    });
+
+    let count = 0;
+    for await (const { data: page } of iterator) {
+      comments.push(...page);
+      count += page.length;
+      if (count >= 500) break; // Hard upper bound to prevent unbounded pagination.
+    }
+
+    // Check for marker-based comment OR @coderabbitai plan text.
+    return comments.some(
+      (c) =>
+        typeof c?.body === 'string' &&
+        (c.body.includes(CODERABBIT_MARKER) || c.body.includes('@coderabbitai plan')),
+    );
+  } catch (error) {
+    console.log('Failed to check existing CodeRabbit plan comments:', {
+      message: error?.message,
+      status: error?.status,
+      owner,
+      repo,
+      issueNumber,
+    });
+    // Return false to allow plan trigger attempt (fail-open for better UX).
+    return false;
+  }
+}
+
+function logSummary(owner, repo, issue) {
+  console.log('=== Summary ===');
+  console.log(`Repository: ${owner}/${repo}`);
+  console.log(`Issue Number: ${issue.number}`);
+  console.log(`Issue Title: ${issue.title || '(no title)'}`);
+  console.log(`Labels: ${issue.labels?.map((l) => l.name).join(', ') || 'none'}`);
+}
+
+// Main workflow handler (default export for workflow usage).
+async function main({ github, context }) {
+  try {
+    const { owner, repo } = context.repo;
+    const { issue, label } = context.payload;
+
+    // Validations.
+    if (!issue?.number) return console.log('No issue in payload');
+
+    if (!hasBeginnerOrHigherLabel(issue, label)) {
+      return console.log('Issue does not have beginner/intermediate/advanced label');
+    }
+
+    if (await hasExistingCodeRabbitPlan(github, owner, repo, issue.number)) {
+      return console.log(`CodeRabbit plan already triggered for #${issue.number}`);
+    }
+
+    // Check for dry run (default to true if not specified, for safety).
+    const isDryRun = (process.env.DRY_RUN || 'true').toLowerCase() === 'true';
+
+    // Post CodeRabbit plan trigger.
+    await triggerCodeRabbitPlan(github, owner, repo, issue, CODERABBIT_MARKER, isDryRun);
+
+    logSummary(owner, repo, issue);
+  } catch (err) {
+    console.log('Error:', {
+      message: err?.message,
+      status: err?.status,
+      owner: context?.repo?.owner,
+      repo: context?.repo?.repo,
+      issueNumber: context?.payload?.issue?.number,
+    });
+  }
+}
+
+// Default export for workflow usage: await script({ github, context }).
+module.exports = main;
+
+// Named exports for reuse by other scripts.
+module.exports.triggerCodeRabbitPlan = triggerCodeRabbitPlan;
+module.exports.hasExistingCodeRabbitPlan = hasExistingCodeRabbitPlan;
+module.exports.CODERABBIT_MARKER = CODERABBIT_MARKER;

--- a/.github/workflows/bot-coderabbit-plan-trigger.yml
+++ b/.github/workflows/bot-coderabbit-plan-trigger.yml
@@ -36,7 +36,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Trigger CodeRabbit Plan
         env:

--- a/.github/workflows/bot-coderabbit-plan-trigger.yml
+++ b/.github/workflows/bot-coderabbit-plan-trigger.yml
@@ -1,0 +1,49 @@
+name: CodeRabbit Plan Trigger
+'on':
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Run without posting comments
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  coderabbit_plan_trigger:
+    runs-on: hl-web-lin-md
+    concurrency:
+      group: coderabbit-plan-${{ github.event.issue.number || github.run_id }}
+      cancel-in-progress: false
+    # Only run when the newly added label is beginner, intermediate, or advanced.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' &&
+      github.event.issue.state == 'open' &&
+      contains(fromJson('["beginner","intermediate","advanced","Beginner","Intermediate","Advanced"]'), github.event.label.name))
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Trigger CodeRabbit Plan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8.0.0
+        with:
+          script: |
+            const script = require('./.github/scripts/coderabbit_plan_trigger.cjs');
+            await script({ github, context });


### PR DESCRIPTION
# Description
<!-- Explain the purpose of this PR -->
To enable the Code Rabbit AI planning similar to hiero-sdk-python.

## Changes Made
- [x] Added...
* A workflow file for coderabbit planning and corresponding script. 
- [ ] Modified...
- [ ] Fixed...

## Related Issues
<!-- Example: Fixes #123, Closes #456 -->
Fixes: #357 

## Screenshots (if applicable)
<!-- Before/after screenshots, UI changes, etc. -->

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Linting passes
- [x] Branch up-to-date with main

## Deployment Notes
<!-- Special instructions for deployment? -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workflow to automatically post a CodeRabbit plan comment on eligible issues when a matching label is applied or when run manually.
  * Added safeguards to avoid duplicate plan comments and support a dry-run mode before posting.
  * Added clearer handling and logging for issue-based automation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->