### PR TITLE
test: run CI on websiteRedesign and add browser-level style checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,13 @@ jobs:
         run: pnpm build
         env:
           NEXT_TELEMETRY_DISABLED: 1
+
+      # Runs after the build so the browser tests exercise the production CSS,
+      # and so `pnpm start` finds .next already in place.
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run browser tests
+        run: pnpm test:e2e
+        env:
+          NEXT_TELEMETRY_DISABLED: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,12 @@ on:
   push:
     branches:
       - main
+      - websiteRedesign
   pull_request:
     branches:
       - main
+      # Long-lived redesign branch. 
+      - websiteRedesign
   workflow_dispatch:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The site will be available at `http://localhost:3000`.
 | --- | --- |
 | `pnpm lint` | Lint the codebase |
 | `pnpm test` | Run unit tests |
+| `pnpm test:e2e` | Run browser tests (needs `pnpm build` first) |
 | `pnpm format` | Format source files |
 | `pnpm format:check` | Check formatting without changing files |
 | `pnpm build` | Build the production app |

--- a/docs/06-testing-and-quality-checks.md
+++ b/docs/06-testing-and-quality-checks.md
@@ -11,6 +11,7 @@ The current project scripts are:
 - `pnpm build`
 - `pnpm start`
 - `pnpm test`
+- `pnpm test:e2e`
 - `pnpm coverage`
 - `pnpm update-snap`
 - `pnpm lint`
@@ -33,8 +34,59 @@ App-level tests live under `src/app/__tests__`, for example
 `src/app/__tests__/not-found.test.tsx` and
 `src/app/__tests__/sitemap.test.ts`.
 
-Although some testing dependencies are installed, the current CI workflows only
-enforce formatting, linting, and a production build.
+## Browser Tests (`e2e/`)
+
+Unit tests run in jsdom, which does not load the stylesheet. That means a
+component test can only assert that a component *emits* a class — never what
+that class does once the cascade has resolved. Both halves have to be true for
+the page to work, and the gap between them is where styling regressions live.
+
+Two real examples, both of which passed lint, Prettier and the full unit suite:
+
+- Nav links rendered `md:text-charcoal` inside a `bg-charcoal` overlay. The
+  class was present, the snapshot matched, and the menu was charcoal text on a
+  charcoal background — blank to a reader.
+- A rule in `globals.css` moved between cascade layers and every `.container`
+  silently capped at 1280px instead of 1820px.
+
+Playwright tests under `e2e/` close that gap by asserting on **computed
+styles in a real browser**. They deliberately check invariants rather than
+pinned values, so a redesign that changes colours and spacing does not have to
+rewrite them:
+
+- navigation text meets the WCAG AA contrast ratio against its effective
+  background, at three viewport widths
+- every menu item sits inside the viewport when the mobile overlay is open
+  (the overlay locks body scrolling, so anything outside it is unreachable)
+- no page scrolls sideways
+
+One of those widths is 700px. It is not a device size — it is the gap that
+opens whenever the JS breakpoint, the utility prefix and a media query in
+`globals.css` stop agreeing. Nobody opens a browser at 700px by accident, which
+is exactly why a regression there survives review.
+
+Run them locally with:
+
+```bash
+pnpm build
+pnpm test:e2e
+```
+
+The suite serves the production build, so the CSS under test is the CSS that
+ships. The first run downloads Chromium via `pnpm exec playwright install
+chromium`.
+
+### Adding to them
+
+Prefer assertions that stay true across a redesign. `expect(ratio).toBeGreaterThan(4.5)`
+survives a new palette; `expect(color).toBe("rgb(184, 26, 86)")` does not, and a
+test that has to be updated on every visual change gets deleted rather than
+fixed.
+
+The contrast helper abstains where it cannot know the answer — if any ancestor
+paints a gradient or image, there is no single background colour to compare
+against, so the element is skipped. That keeps hero sections from producing
+false failures.
 
 ## Recommended Local Checks
 
@@ -45,6 +97,7 @@ pnpm format:check
 pnpm lint
 pnpm test
 pnpm build
+pnpm test:e2e
 ```
 
 If you changed files under `src/`, it is often useful to run:
@@ -90,6 +143,15 @@ Runs the Vitest suite once in `jsdom`.
 Tests live beside the code they cover inside `__tests__` directories, for
 example `src/lib/__tests__/posts.test.ts`.
 
+### `pnpm test:e2e`
+
+Runs the Playwright suite in `e2e/` against a real browser. Needs a production
+build first (`pnpm build`), because the config serves the site with
+`pnpm start`.
+
+See [Browser Tests](#browser-tests-e2e) for what these cover and why they
+exist alongside the Vitest suite.
+
 ### `pnpm coverage`
 
 Runs the same Vitest suite with V8 coverage enabled.
@@ -134,8 +196,13 @@ The current `CI` workflow runs:
 3. `pnpm lint`
 4. `pnpm test`
 5. `pnpm build`
+6. `pnpm test:e2e`
 
 If one of these fails locally, it will likely fail in GitHub Actions too.
+
+CI runs on pull requests into `main` and into `websiteRedesign`. The second
+entry exists because the redesign branch is long-lived: PRs into it previously
+merged without any of these checks running at all.
 
 ## Content-Specific Validation Tips
 

--- a/e2e/helpers/contrast.ts
+++ b/e2e/helpers/contrast.ts
@@ -1,0 +1,157 @@
+/**
+ * Runs inside the page. Returns every visible text-bearing element whose
+ * contrast against its *effective* background falls below the WCAG AA
+ * threshold for its size.
+ *
+ * "Effective" background matters: an element is usually transparent, so the
+ * colour a reader actually sees comes from an ancestor. Walking up and
+ * compositing is what catches charcoal text sitting on a charcoal overlay --
+ * both elements are individually fine, and only the pair is broken.
+ */
+export const AA_NORMAL = 4.5;
+export const AA_LARGE = 3;
+
+export interface ContrastFailure {
+  text: string;
+  selector: string;
+  color: string;
+  background: string;
+  ratio: number;
+  required: number;
+  fontSize: number;
+}
+
+export function collectContrastFailures(rootSelector = "body"): ContrastFailure[] {
+  // Declared inside the function on purpose: page.evaluate ships the function
+  // body to the browser, so anything at module scope is not defined there.
+  const aaNormal = 4.5;
+  const aaLarge = 3;
+
+  type Rgba = { r: number; g: number; b: number; a: number };
+
+  const parse = (value: string): Rgba | null => {
+    const m = value.match(/rgba?\(([^)]+)\)/);
+    if (!m) return null;
+    const parts = m[1].split(/[,\s/]+/).filter(Boolean).map(Number);
+    const [r, g, b, a = 1] = parts;
+    if ([r, g, b].some(Number.isNaN)) return null;
+    return { r, g, b, a };
+  };
+
+  // src over dst, both premultiplied out to plain rgb.
+  const over = (src: Rgba, dst: Rgba): Rgba => {
+    const a = src.a + dst.a * (1 - src.a);
+    if (a === 0) return { r: 0, g: 0, b: 0, a: 0 };
+    const blend = (s: number, d: number) =>
+      (s * src.a + d * dst.a * (1 - src.a)) / a;
+    return {
+      r: blend(src.r, dst.r),
+      g: blend(src.g, dst.g),
+      b: blend(src.b, dst.b),
+      a,
+    };
+  };
+
+  const luminance = ({ r, g, b }: Rgba) => {
+    const channel = (c: number) => {
+      const s = c / 255;
+      return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    };
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+  };
+
+  const ratio = (fg: Rgba, bg: Rgba) => {
+    const [a, b] = [luminance(fg), luminance(bg)].sort((x, y) => y - x);
+    return (a + 0.05) / (b + 0.05);
+  };
+
+  const isHidden = (el: Element) => {
+    const cs = getComputedStyle(el);
+    if (cs.visibility === "hidden" || cs.display === "none") return true;
+    if (Number(cs.opacity) === 0) return true;
+    const box = el.getBoundingClientRect();
+    return box.width === 0 || box.height === 0;
+  };
+
+  const hiddenBranch = (el: Element) => {
+    for (let n: Element | null = el; n; n = n.parentElement) {
+      if (isHidden(n)) return true;
+      if (n.getAttribute("aria-hidden") === "true") return true;
+    }
+    return false;
+  };
+
+  /**
+   * null means "cannot be known from computed styles alone" -- an ancestor
+   * paints a gradient or image, so there is no single background colour to
+   * compare against. Those elements are skipped rather than guessed at; a
+   * false failure on every hero would get the whole check switched off.
+   */
+  const effectiveBackground = (el: Element): Rgba | null => {
+    let acc: Rgba = { r: 0, g: 0, b: 0, a: 0 };
+    for (let n: Element | null = el; n; n = n.parentElement) {
+      const cs = getComputedStyle(n);
+      if (cs.backgroundImage !== "none") return null;
+      const bg = parse(cs.backgroundColor);
+      if (bg && bg.a > 0) {
+        acc = over(acc, bg);
+        if (acc.a >= 1) return acc;
+      }
+    }
+    // Nothing opaque all the way up: the canvas is white.
+    return over(acc, { r: 255, g: 255, b: 255, a: 1 });
+  };
+
+  const describe = (el: Element) => {
+    const id = el.id ? `#${el.id}` : "";
+    const cls = el.className && typeof el.className === "string"
+      ? "." + el.className.trim().split(/\s+/).slice(0, 3).join(".")
+      : "";
+    return `${el.tagName.toLowerCase()}${id}${cls}`;
+  };
+
+  const failures: ContrastFailure[] = [];
+
+  const root = document.querySelector(rootSelector);
+  if (!root) throw new Error(`contrast root not found: ${rootSelector}`);
+
+  for (const el of Array.from(root.querySelectorAll("*"))) {
+    // Only elements that render their own text, so each string is judged once.
+    const own = Array.from(el.childNodes)
+      .filter(n => n.nodeType === Node.TEXT_NODE)
+      .map(n => n.textContent ?? "")
+      .join("")
+      .trim();
+    if (!own) continue;
+    if (hiddenBranch(el)) continue;
+
+    const cs = getComputedStyle(el);
+    const fg = parse(cs.color);
+    if (!fg) continue;
+
+    const bg = effectiveBackground(el);
+    if (!bg) continue;
+
+    const composited = over(fg, bg);
+    const value = ratio(composited, bg);
+
+    const fontSize = parseFloat(cs.fontSize);
+    const bold = Number(cs.fontWeight) >= 700;
+    const large = fontSize >= 24 || (bold && fontSize >= 18.66);
+    const required = large ? aaLarge : aaNormal;
+
+    if (value < required) {
+      failures.push({
+        text: own.slice(0, 40),
+        selector: describe(el),
+        color: cs.color,
+        background: `rgb(${Math.round(bg.r)}, ${Math.round(bg.g)}, ${Math.round(bg.b)})`,
+        ratio: Math.round(value * 100) / 100,
+        required,
+        fontSize,
+      });
+    }
+  }
+
+  return failures;
+}

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+import { collectContrastFailures } from "./helpers/contrast";
+
+/**
+ * 700px is deliberate. It is not a device size -- it is the gap that opens up
+ * whenever the JS breakpoint, the utility prefix and a media query in
+ * globals.css stop agreeing. Nobody opens a browser at 700px by accident,
+ * which is exactly why a regression there survives review.
+ */
+const WIDTHS = [
+  { name: "mobile", width: 375, height: 667 },
+  { name: "between", width: 700, height: 800 },
+  { name: "desktop", width: 1280, height: 900 },
+];
+
+async function openMenuIfPresent(page: import("@playwright/test").Page) {
+  const opener = page.getByRole("button", { name: "Open menu" });
+  if (!(await opener.isVisible().catch(() => false))) return false;
+  await opener.click();
+  await expect(page.locator("#navigation")).toHaveAttribute(
+    "aria-hidden",
+    "false",
+  );
+  return true;
+}
+
+for (const { name, width, height } of WIDTHS) {
+  test.describe(`${name} (${width}x${height})`, () => {
+    test.use({ viewport: { width, height } });
+
+    test("navigation text is readable against its background", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await openMenuIfPresent(page);
+
+      // Scoped to the header: the nav overlay and the bar behind it are the
+      // pair that has actually gone wrong, and a site-wide sweep would need
+      // its own pass over pre-existing content first.
+      const failures = await page.evaluate(collectContrastFailures, "header");
+
+      expect(
+        failures,
+        `Unreadable navigation text at ${width}px:\n` +
+          failures
+            .map(
+              f =>
+                `  "${f.text}" ${f.color} on ${f.background} = ${f.ratio}:1 (needs ${f.required}:1)`,
+            )
+            .join("\n"),
+      ).toEqual([]);
+    });
+
+    test("every menu item is reachable inside the viewport", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      const opened = await openMenuIfPresent(page);
+      test.skip(!opened, "no mobile menu at this width");
+
+      const clipped = await page.evaluate(() => {
+        const items = Array.from(
+          document.querySelectorAll("#menu > li"),
+        ) as HTMLElement[];
+        return items
+          .map(li => {
+            const box = li.getBoundingClientRect();
+            return {
+              text: (li.textContent ?? "").trim().slice(0, 30),
+              top: Math.round(box.top),
+              bottom: Math.round(box.bottom),
+            };
+          })
+          .filter(i => i.top < 0 || i.bottom > window.innerHeight);
+      });
+
+      // The overlay locks body scrolling, so anything outside the viewport
+      // cannot be scrolled to -- it is simply unreachable.
+      expect(
+        clipped,
+        `Menu items outside the viewport at ${width}x${height}:\n` +
+          clipped
+            .map(i => `  "${i.text}" top=${i.top} bottom=${i.bottom}`)
+            .join("\n"),
+      ).toEqual([]);
+    });
+
+    test("the page does not scroll sideways", async ({ page }) => {
+      await page.goto("/");
+      const overflow = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+      expect(overflow.scrollWidth).toBeLessThanOrEqual(
+        overflow.clientWidth + 1,
+      );
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "pnpm sync:repo-stats && next build",
     "start": "next start",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "coverage": "vitest run --coverage",
     "update-snap": "vitest run --update",
     "lint": "eslint .",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "^5.15.12",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Browser-level checks for things jsdom cannot see.
+ *
+ * Unit tests assert that a component *emits* a class; only a real browser
+ * resolves what that class actually does once the cascade has had its say.
+ * Every regression these guard against shipped green through lint, Prettier
+ * and the vitest suite.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    // Runs against the production build, so the CSS under test is the CSS we ship.
+    // CI builds in an earlier step, so `start` finds .next already there.
+    command: "pnpm start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 5.2.1
       next:
         specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -46,6 +46,9 @@ importers:
       '@netlify/plugin-nextjs':
         specifier: ^5.15.12
         version: 5.15.12
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -381,89 +384,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -537,24 +556,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.11':
     resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.11':
     resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.11':
     resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.11':
     resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
@@ -586,6 +609,11 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -622,36 +650,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
@@ -726,24 +760,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -965,51 +1003,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -1612,6 +1660,11 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2010,24 +2063,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2333,6 +2390,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3363,6 +3430,10 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@oxc-project/types@0.139.0': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -4488,6 +4559,9 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5227,7 +5301,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.11(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.11(@babel/core@7.29.7)(@playwright/test@1.62.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
@@ -5246,6 +5320,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.11
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5360,6 +5435,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/data/repository_stats.json
+++ b/src/data/repository_stats.json
@@ -1,10 +1,10 @@
 {
   "hiero-consensus-node": { "stars": 402 },
   "hiero-local-node": { "stars": 262 },
-  "hiero-mirror-node": { "stars": 184 },
+  "hiero-mirror-node": { "stars": 185 },
   "hiero-improvement-proposals": { "stars": 177 },
   "hiero-sdk-js": { "stars": 325 },
-  "hiero-sdk-java": { "stars": 258 },
+  "hiero-sdk-java": { "stars": 257 },
   "hiero-json-rpc-relay": { "stars": 91 },
   "hiero-sdk-go": { "stars": 127 },
   "hiero-sdk-rust": { "stars": 58 },

--- a/src/data/repository_stats.json
+++ b/src/data/repository_stats.json
@@ -1,10 +1,10 @@
 {
   "hiero-consensus-node": { "stars": 402 },
   "hiero-local-node": { "stars": 262 },
-  "hiero-mirror-node": { "stars": 185 },
+  "hiero-mirror-node": { "stars": 184 },
   "hiero-improvement-proposals": { "stars": 177 },
   "hiero-sdk-js": { "stars": 325 },
-  "hiero-sdk-java": { "stars": 257 },
+  "hiero-sdk-java": { "stars": 258 },
   "hiero-json-rpc-relay": { "stars": 91 },
   "hiero-sdk-go": { "stars": 127 },
   "hiero-sdk-rust": { "stars": 58 },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -16,5 +16,9 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest-setup.ts"],
     testTimeout: 10000,
+    // e2e/ is Playwright's; it imports @playwright/test, which Vitest cannot
+    // run. `.next` is excluded too because `output: "standalone"` copies the
+    // specs into the traced bundle, where they would be picked up again.
+    exclude: ["**/node_modules/**", "**/dist/**", "e2e/**", ".next/**"],
   },
 });


### PR DESCRIPTION
# Description

Two related gaps in how this branch is verified, and the tests that close the second one.

**CI never ran on this branch.** `ci.yml` triggered on `pull_request` into `main` only, so every PR into `websiteRedesign` merged without lint, Prettier, unit tests or a build ever executing. #569 currently shows all checks green with a failing unit test.

**Unit tests cannot see CSS.** They run in jsdom, which never loads the stylesheet, so a component test can only assert that a component *emits* a class — never what that class does once the cascade has resolved. Both halves have to be true for the page to work, and the gap between them is where styling regressions live.

## Changes Made

- [x] `ci.yml` now triggers on PRs into `websiteRedesign` as well as `main`
- [x] Playwright suite under `e2e/`, run in CI after the build so it exercises production CSS
- [x] `pnpm test:e2e` script; Vitest excludes `e2e/` and `.next/`
- [x] Documented in `docs/06-testing-and-quality-checks.md` and the `README.md` command table

## What the browser tests check

Invariants, not pinned values, at 375 / 700 / 1280:

- navigation text meets the WCAG AA contrast ratio against its **effective** background — walking up ancestors and compositing alpha, since each element is individually fine and only the pair is broken
- every menu item sits inside the viewport when the mobile overlay is open (the overlay locks body scrolling, so anything outside it is unreachable)
- no page scrolls sideways

`expect(ratio).toBeGreaterThan(4.5)` survives a new palette. `expect(color).toBe("rgb(184, 26, 86)")` would need rewriting on every visual change, and a test like that gets deleted rather than fixed — which matters a lot on a branch whose whole purpose is changing how the site looks.

**700px is deliberate.** It is not a device size. It is the gap that opens whenever the JS breakpoint, the utility prefix and a media query in `globals.css` stop agreeing. Nobody opens a browser at 700px by accident, which is exactly why a regression there survives review.

The contrast helper **abstains** where it cannot know the answer: if any ancestor paints a gradient or image, there is no single background colour to compare against, so the element is skipped. Without that, every hero section produced a false failure — which is how a check like this ends up switched off.

## Verification

Confirmed the suite catches real regressions, not just hypothetical ones. Cherry-picked onto `509-web-br` (#569's current state) it fails with the precise diagnosis:

```
Unreadable navigation text at 700px:
  "Contribute"  rgb(30, 30, 30) on rgb(30, 30, 30) = 1:1 (needs 4.5:1)
  "Connect"     rgb(30, 30, 30) on rgb(30, 30, 30) = 1:1 (needs 4.5:1)
  ... all six links

Menu items outside the viewport at 375x667:
  "Contribute"  top=-29  bottom=78
  ""            top=661  bottom=696
```

Both are live bugs on that branch today, and both passed lint, Prettier and the full unit suite.

On `websiteRedesign` the suite is clean: 7 passed, 2 skipped (the menu tests skip where there is no mobile menu at that width; they activate at 700px once #569 moves the breakpoint to 768).

Local run on this branch: unit 78/78 · Playwright 7 passed 2 skipped · lint clean · Prettier clean · build clean.

## Note on checks for this PR

This PR will show no CI run of its own. For `pull_request` events GitHub reads the workflow file from the **base** branch, so the trigger has to land on `websiteRedesign` before anything downstream of it gets checked. Unavoidable in any arrangement — the next PR into this branch will get the full run, including Playwright.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated
- [x] Linting passes
- [x] Branch up-to-date with base

## Deployment Notes

None. No application code changes — CI configuration, test infrastructure and docs only.
