### PR TITLE
refactor: move globals.css into Tailwind cascade layers

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,389 +57,405 @@
 }
 
 /* ============================================
-   Base Styles
+   Authored CSS lives in Tailwind's cascade layers.
+   Unlayered rules outrank every utility regardless of
+   specificity, so anything written outside a layer here
+   silently overrides component-level Tailwind classes.
    ============================================ */
-html {
-  scroll-behavior: smooth;
-}
 
-body {
-  @apply m-0 text-charcoal leading-normal font-serif;
-}
+@layer base {
+  /* ============================================
+     Base Styles
+     ============================================ */
+  html {
+    scroll-behavior: smooth;
+  }
 
-header {
-  @apply border-b border-charcoal border-solid;
-}
+  body {
+    @apply m-0 text-charcoal leading-normal font-serif;
+  }
 
-/* The footer has no border rule of its own: it draws a gradient top edge
-   inside the component, see components/Footer. */
+  header {
+    @apply border-b border-charcoal border-solid;
+  }
 
-main a:not([class]) {
-  @apply text-red underline;
-}
+  /* The footer has no border rule of its own: it draws a gradient top edge
+     inside the component, see components/Footer. */
 
-/* ============================================
-   Navbar Styles
-   Scoped to the header so the footer navigation
-   can define its own styling.
-   ============================================ */
-header nav a {
-  @apply text-white no-underline;
-  font-size: 2.375rem;
-  line-height: 5.188rem;
-  letter-spacing: -0.128rem;
-  @apply transition-colors duration-300 ease-in-out;
-  position: relative;
-}
+  main a:not([class]) {
+    @apply text-red underline;
+  }
 
-header nav a:hover {
-  color: #D92D6A;
-}
-
-header nav a.active {
-  @apply font-bold;
-}
-
-header nav a.active::after {
-  content: '';
-  position: absolute;
-  bottom: 2rem;
-  left: 25%;
-  width: 50%;
-  height: 3px;
-  background-color: #D92D6A;
-  transform: translateX(-50%);
-}
-
-/* Desktop nav */
-@media (min-width: 640px) {
+  /* ============================================
+     Navbar Styles
+     Scoped to the header so the footer navigation
+     can define its own styling.
+     ============================================ */
   header nav a {
-    @apply text-charcoal text-base leading-normal;
+    @apply text-white no-underline;
+    font-size: 2.375rem;
+    line-height: 5.188rem;
+    letter-spacing: -0.128rem;
+    @apply transition-colors duration-300 ease-in-out;
+    position: relative;
   }
+
   header nav a:hover {
-    color: #B81A56;
+    color: #D92D6A;
   }
+
   header nav a.active {
-    color: #B81A56;
+    @apply font-bold;
   }
+
   header nav a.active::after {
-    bottom: -4px;
-    left: 0;
-    width: 100%;
-    transform: none;
+    content: '';
+    position: absolute;
+    bottom: 2rem;
+    left: 25%;
+    width: 50%;
+    height: 3px;
+    background-color: #D92D6A;
+    transform: translateX(-50%);
+  }
+
+  /* Desktop nav */
+  @media (min-width: 640px) {
+    header nav a {
+      @apply text-charcoal text-base leading-normal;
+    }
+    header nav a:hover {
+      color: #B81A56;
+    }
+    header nav a.active {
+      color: #B81A56;
+    }
+    header nav a.active::after {
+      bottom: -4px;
+      left: 0;
+      width: 100%;
+      transform: none;
+    }
+  }
+
+  /* Mobile menu */
+  @media (max-width: 640px) {
+    header nav a.active {
+      background-color: rgba(184, 26, 86, 0.1) !important;
+      border-bottom: 2px solid #B81A56 !important;
+      box-shadow: none !important;
+    }
+    header nav a.active::after {
+      display: none;
+    }
+    header nav a:focus-visible {
+      outline: 2px solid #D92D6A;
+      outline-offset: 3px;
+    }
+  }
+
+  /* Desktop focus */
+  @media (min-width: 640px) {
+    header nav a:focus-visible {
+      @apply outline-none ring-2 ring-red-light ring-offset-2;
+    }
   }
 }
 
-/* Mobile menu */
-@media (max-width: 640px) {
-  header nav a.active {
-    background-color: rgba(184, 26, 86, 0.1) !important;
-    border-bottom: 2px solid #B81A56 !important;
-    box-shadow: none !important;
-  }
-  header nav a.active::after {
-    display: none;
-  }
-  header nav a:focus-visible {
-    outline: 2px solid #D92D6A;
-    outline-offset: 3px;
-  }
-}
-
-/* Desktop focus */
-@media (min-width: 640px) {
-  header nav a:focus-visible {
-    @apply outline-none ring-2 ring-red-light ring-offset-2;
-  }
-}
-
+/* Deliberately unlayered: this has to beat the `hidden` utility that Menu
+   puts on the nav, and a layered rule always loses to a utility. Delete it
+   together with the `.active-navigation` hook in components/Menu. */
 .active-navigation {
   @apply flex;
 }
 
 /* ============================================
-   Anchors & section offsets
-   ============================================ */
-.anchor {
-  margin-top: -6.813rem;
-  padding-top: 6.813rem;
-}
-
-.anchor--roadmap {
-  margin-top: -5rem;
-  padding-top: 5rem;
-}
-
-@media (min-width: 640px) {
-  .anchor--open-source {
-    margin-top: -12.5rem;
-    padding-top: 12.5rem;
-  }
-  .anchor--roadmap {
-    margin-top: 0;
-    padding-top: 0;
-  }
-}
-
-/* ============================================
    Container
+   Declared with `@utility` rather than as a plain class: Tailwind ships its
+   own `container` utility, and a class in a layer would lose to it. `@utility`
+   replaces the built-in instead of competing with it.
    ============================================ */
-.container {
+@utility container {
   @apply w-full mx-auto;
   padding-left: 1.563rem;
   padding-right: 1.563rem;
-}
 
-.container-mobile-full {
-  @apply p-0;
-}
-
-@media (min-width: 640px) {
-  .container {
+  @media (min-width: 640px) {
     max-width: 768px;
   }
-}
 
-@media (min-width: 768px) {
-  .container {
+  @media (min-width: 768px) {
     max-width: 1024px;
     @apply px-12;
   }
-}
 
-@media (min-width: 1024px) {
-  .container,
-  .container-mobile-full {
+  @media (min-width: 1024px) {
     max-width: 1820px;
     padding-left: 8.75rem;
     padding-right: 8.75rem;
   }
 }
 
-/* ============================================
-   Swiper overrides
-   ============================================ */
-.swiper {
-  @apply w-full h-full;
-  max-width: 932px;
+@utility container-mobile-full {
+  @apply p-0;
+
+  @media (min-width: 1024px) {
+    max-width: 1820px;
+    padding-left: 8.75rem;
+    padding-right: 8.75rem;
+  }
 }
 
-.reposSwiper {
-  @apply max-w-full;
-}
+@layer components {
+  /* ============================================
+     Anchors & section offsets
+     ============================================ */
+  .anchor {
+    margin-top: -6.813rem;
+    padding-top: 6.813rem;
+  }
 
-.reposSwiper .swiper-slide {
-  @apply text-left text-base;
-  font-family: inherit;
-}
-
-.swiper-slide {
-  @apply font-serif text-center text-lg;
-}
-
-.swiper .swiper-button {
-  @apply top-auto text-charcoal bg-white-dark;
-  bottom: 5rem;
-  width: 35px;
-  height: 35px;
-}
-
-.swiper .swiper-button::after {
-  @apply text-sm;
-}
-
-.swiper .swiper-button-prev {
-  left: calc(50% - 40px);
-}
-
-.swiper .swiper-button-next {
-  right: calc(50% - 40px);
-}
-
-/* ============================================
-   Blog / Article content prose styles
-   ============================================ */
-.content {
-  :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-    @apply relative text-charcoal border-red py-2 pr-6;
-    margin-top: 86px;
-    @apply mb-6 first:mt-0;
-    border-left-width: 2px;
-    @apply pl-6;
+  .anchor--roadmap {
+    margin-top: -5rem;
+    padding-top: 5rem;
   }
 
   @media (min-width: 640px) {
+    .anchor--open-source {
+      margin-top: -12.5rem;
+      padding-top: 12.5rem;
+    }
+    .anchor--roadmap {
+      margin-top: 0;
+      padding-top: 0;
+    }
+  }
+
+  /* ============================================
+     Swiper overrides
+     ============================================ */
+  .swiper {
+    @apply w-full h-full;
+    max-width: 932px;
+  }
+
+  .reposSwiper {
+    @apply max-w-full;
+  }
+
+  .reposSwiper .swiper-slide {
+    @apply text-left text-base;
+    font-family: inherit;
+  }
+
+  .swiper-slide {
+    @apply font-serif text-center text-lg;
+  }
+
+  .swiper .swiper-button {
+    @apply top-auto text-charcoal bg-white-dark;
+    bottom: 5rem;
+    width: 35px;
+    height: 35px;
+  }
+
+  .swiper .swiper-button::after {
+    @apply text-sm;
+  }
+
+  .swiper .swiper-button-prev {
+    left: calc(50% - 40px);
+  }
+
+  .swiper .swiper-button-next {
+    right: calc(50% - 40px);
+  }
+
+  /* ============================================
+     Blog / Article content prose styles
+     ============================================ */
+  .content {
     :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-      @apply my-6 py-4;
-      margin-left: 92px;
+      @apply relative text-charcoal border-red py-2 pr-6;
+      margin-top: 86px;
+      @apply mb-6 first:mt-0;
+      border-left-width: 2px;
+      @apply pl-6;
     }
-  }
 
-  :where(blockquote)::before {
-    content: '';
-    @apply block absolute;
-    top: -60px;
-    left: -3px;
-    width: 50px;
-    height: 40px;
-    background-image: url("/images/Hiero-Icon-Quote-Left.svg");
-  }
+    @media (min-width: 640px) {
+      :where(blockquote):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+        @apply my-6 py-4;
+        margin-left: 92px;
+      }
+    }
 
-  @media (min-width: 640px) {
     :where(blockquote)::before {
-      top: 0;
-      left: -92px;
+      content: '';
+      @apply block absolute;
+      top: -60px;
+      left: -3px;
+      width: 50px;
+      height: 40px;
+      background-image: url("/images/Hiero-Icon-Quote-Left.svg");
+    }
+
+    @media (min-width: 640px) {
+      :where(blockquote)::before {
+        top: 0;
+        left: -92px;
+      }
+    }
+
+    h2 {
+      @apply font-medium mt-8 mb-4;
+      font-size: 24px;
+    }
+
+    h3 {
+      @apply font-medium text-lg mt-8 mb-4;
+    }
+
+    h4 {
+      @apply font-medium text-base mt-8 mb-4;
+    }
+
+    cite {
+      @apply block text-red font-medium not-italic mt-4;
+    }
+
+    p:has(cite) {
+      @apply mb-0;
+    }
+
+    p {
+      @apply mb-4;
+    }
+
+    p img {
+      @apply my-7;
+    }
+
+    ol {
+      @apply list-decimal my-4 pl-6;
+    }
+
+    ul {
+      @apply list-disc my-4 pl-6;
+    }
+
+    table {
+      @apply w-full my-6 border-collapse;
+    }
+
+    th,
+    td {
+      @apply border border-gray px-4 py-3 text-left;
+    }
+
+    th {
+      @apply bg-red text-white font-semibold;
+    }
+
+    tr:nth-child(even) {
+      @apply bg-gray-light;
+    }
+
+    tr:hover {
+      @apply bg-sand;
     }
   }
 
-  h2 {
-    @apply font-medium mt-8 mb-4;
-    font-size: 24px;
+  /* ============================================
+     Code blocks
+     ============================================ */
+  .highlight {
+    @apply relative mb-6;
   }
 
-  h3 {
-    @apply font-medium text-lg mt-8 mb-4;
+  .highlight pre {
+    @apply pt-8 pb-3 px-3 rounded-md;
+    background-color: #1E1E1E !important;
   }
 
-  h4 {
-    @apply font-medium text-base mt-8 mb-4;
+  code {
+    @apply whitespace-pre-wrap text-xs font-ibm;
+    word-break: break-word;
   }
 
-  cite {
-    @apply block text-red font-medium not-italic mt-4;
+  .copy-button {
+    @apply bg-transparent border-none cursor-pointer p-0 absolute right-2 top-2 opacity-100;
   }
 
-  p:has(cite) {
-    @apply mb-0;
+  .highlight:hover .copy-button {
+    @apply opacity-100;
   }
 
-  p {
-    @apply mb-4;
+  .copy-button > svg {
+    width: 18px;
   }
 
-  p img {
-    @apply my-7;
+  .copy-button > svg > path {
+    @apply fill-white;
   }
 
-  ol {
-    @apply list-decimal my-4 pl-6;
+  /* ============================================
+     Pagination
+     ============================================ */
+  .pagination {
+    @apply flex gap-2 mx-auto mt-16 justify-center;
   }
 
-  ul {
-    @apply list-disc my-4 pl-6;
+  .pagination .page-item.disabled {
+    opacity: 0.3;
   }
 
-  table {
-    @apply w-full my-6 border-collapse;
+  .pagination .page-item.disabled .page-link {
+    @apply cursor-default;
   }
 
-  th,
-  td {
-    @apply border border-gray px-4 py-3 text-left;
+  .pagination .page-item .page-link {
+    @apply bg-sand flex justify-center items-center rounded-full leading-none no-underline text-base font-bold text-charcoal cursor-pointer;
+    width: 2.5rem;
+    height: 2.5rem;
   }
 
-  th {
-    @apply bg-red text-white font-semibold;
+  .pagination .page-item:has([aria-label="Previous"]) .page-link,
+  .pagination .page-item:has([aria-label="First"]) .page-link,
+  .pagination .page-item:has([aria-label="Next"]) .page-link,
+  .pagination .page-item:has([aria-label="Last"]) .page-link {
+    @apply bg-transparent;
   }
 
-  tr:nth-child(even) {
-    @apply bg-gray-light;
+  .pagination .page-item:has([aria-label="Previous"]) .page-link span,
+  .pagination .page-item:has([aria-label="First"]) .page-link span,
+  .pagination .page-item:has([aria-label="Next"]) .page-link span,
+  .pagination .page-item:has([aria-label="Last"]) .page-link span {
+    @apply hidden;
   }
 
-  tr:hover {
-    @apply bg-sand;
+  .pagination .page-item:has([aria-label="Previous"]) .page-link::before,
+  .pagination .page-item:has([aria-label="Next"]) .page-link::before {
+    content: '';
+    width: 0.5rem;
+    height: 0.75rem;
+    background-image: url("data:image/svg+xml,%3Csvg id='arrow-single' xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 8 12'%3E%3Cpath d='M6.1,12l1.4-1.4L2.9,6,7.5,1.4,6.1,0,0,6l6,6Z'/%3E%3C/svg%3E");
   }
-}
 
-/* ============================================
-   Code blocks
-   ============================================ */
-.highlight {
-  @apply relative mb-6;
-}
+  .pagination .page-item:has([aria-label="First"]) .page-link::before,
+  .pagination .page-item:has([aria-label="Last"]) .page-link::before {
+    content: '';
+    width: 14px;
+    height: 0.75rem;
+    background-image: url("data:image/svg+xml,%3Csvg id='arrow-double' xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 14 12'%3E%3Cpath d='M6.1,12l1.4-1.4L2.9,6,7.5,1.4,6.1,0,0,6l6,6Z'/%3E%3Cpath d='M12.1,12l1.4-1.4-4.6-4.6L13.5,1.4,12.1,0l-6,6,6,6Z'/%3E%3C/svg%3E");
+  }
 
-.highlight pre {
-  @apply pt-8 pb-3 px-3 rounded-md;
-  background-color: #1E1E1E !important;
-}
+  .pagination .page-item:has([aria-label="Next"]) .page-link::before,
+  .pagination .page-item:has([aria-label="Last"]) .page-link::before {
+    transform: rotate(180deg);
+  }
 
-code {
-  @apply whitespace-pre-wrap text-xs font-ibm;
-  word-break: break-word;
-}
-
-.copy-button {
-  @apply bg-transparent border-none cursor-pointer p-0 absolute right-2 top-2 opacity-100;
-}
-
-.highlight:hover .copy-button {
-  @apply opacity-100;
-}
-
-.copy-button > svg {
-  width: 18px;
-}
-
-.copy-button > svg > path {
-  @apply fill-white;
-}
-
-/* ============================================
-   Pagination
-   ============================================ */
-.pagination {
-  @apply flex gap-2 mx-auto mt-16 justify-center;
-}
-
-.pagination .page-item.disabled {
-  opacity: 0.3;
-}
-
-.pagination .page-item.disabled .page-link {
-  @apply cursor-default;
-}
-
-.pagination .page-item .page-link {
-  @apply bg-sand flex justify-center items-center rounded-full leading-none no-underline text-base font-bold text-charcoal cursor-pointer;
-  width: 2.5rem;
-  height: 2.5rem;
-}
-
-.pagination .page-item:has([aria-label="Previous"]) .page-link,
-.pagination .page-item:has([aria-label="First"]) .page-link,
-.pagination .page-item:has([aria-label="Next"]) .page-link,
-.pagination .page-item:has([aria-label="Last"]) .page-link {
-  @apply bg-transparent;
-}
-
-.pagination .page-item:has([aria-label="Previous"]) .page-link span,
-.pagination .page-item:has([aria-label="First"]) .page-link span,
-.pagination .page-item:has([aria-label="Next"]) .page-link span,
-.pagination .page-item:has([aria-label="Last"]) .page-link span {
-  @apply hidden;
-}
-
-.pagination .page-item:has([aria-label="Previous"]) .page-link::before,
-.pagination .page-item:has([aria-label="Next"]) .page-link::before {
-  content: '';
-  width: 0.5rem;
-  height: 0.75rem;
-  background-image: url("data:image/svg+xml,%3Csvg id='arrow-single' xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 8 12'%3E%3Cpath d='M6.1,12l1.4-1.4L2.9,6,7.5,1.4,6.1,0,0,6l6,6Z'/%3E%3C/svg%3E");
-}
-
-.pagination .page-item:has([aria-label="First"]) .page-link::before,
-.pagination .page-item:has([aria-label="Last"]) .page-link::before {
-  content: '';
-  width: 14px;
-  height: 0.75rem;
-  background-image: url("data:image/svg+xml,%3Csvg id='arrow-double' xmlns='http://www.w3.org/2000/svg' version='1.1' viewBox='0 0 14 12'%3E%3Cpath d='M6.1,12l1.4-1.4L2.9,6,7.5,1.4,6.1,0,0,6l6,6Z'/%3E%3Cpath d='M12.1,12l1.4-1.4-4.6-4.6L13.5,1.4,12.1,0l-6,6,6,6Z'/%3E%3C/svg%3E");
-}
-
-.pagination .page-item:has([aria-label="Next"]) .page-link::before,
-.pagination .page-item:has([aria-label="Last"]) .page-link::before {
-  transform: rotate(180deg);
-}
-
-.pagination .page-item.active .page-link {
-  @apply bg-red text-white;
+  .pagination .page-item.active .page-link {
+    @apply bg-red text-white;
+  }
 }


### PR DESCRIPTION
# Description

Authored CSS in `globals.css` sat outside any `@layer`. Unlayered rules outrank every layered rule **regardless of specificity**, so a bare `header nav a` selector silently beats component-level Tailwind utilities. The class lands in the DOM and shows up in snapshots, but never takes effect.

This is the mechanism behind the styling problems on this branch. Each PR that moves styling into a component narrows or dodges the global rule in its way rather than deleting it, and the next PR inherits it — #567 renamed `nav a` to `header nav a` to free the footer, and #569 then redesigned the header and walked straight into the rule #567 had just aimed at it.

Wrapping the authored rules in layers means a forgotten rule costs dead bytes instead of a broken component. The failure mode degrades from silent-and-invisible to harmless.

## Changes Made

- [x] Wrapped authored rules in `@layer base` / `@layer components`
- [x] Moved `.container` to `@utility`
- [x] Left `.active-navigation` unlayered, with a comment explaining why

No rules deleted, no component changes.

## The two deliberate exceptions

**`.active-navigation` stays unlayered.** It has to beat the `hidden` utility that `Menu` puts on the nav, and a layered rule always loses to a utility. Layering it would mean the mobile menu never opens. Commented in place; it gets deleted alongside the navbar work in #569, which is what replaces it.

**`.container` became `@utility`.** Tailwind v4 ships its own `container` utility — the custom one was only winning by being unlayered. Moving it into `components` silently capped every container at 1280px instead of 1820px, on 13 elements on the home page alone. `@utility` replaces the built-in rather than competing with it, which is the idiomatic v4 answer and keeps the class name so no component has to change.

## Why the nav CSS is not deleted here

On this branch `Menu/index.tsx` still renders `.active` and `.active-navigation`, and the links carry no Tailwind typography at all — `header nav a` is currently the *only* thing styling the navbar. Deleting it now would leave the nav unstyled.

The deletion belongs in #569, which is the PR that replaces those styles. Layering is the functional fix and lands here; the delete is hygiene and lands with its replacement.

## Verification

**No visual change.** Verified with a computed-style fingerprint — 45 CSS properties on every element, captured before the edit and diffed after:

| Page | Elements | Diffs |
|---|---|---|
| home @1280 | 399 | 0 |
| blog index @1280 | 182 | 0 |
| blog post @1280 | 255 | 0 |
| home, menu open @375 | 399 | 0 |

The `.container` regression above was caught by exactly this method — it is the reason the `@utility` change is in here.

Confirmed in the compiled output that `header nav a` moved from unlayered (line 3106) into `@layer base` (line 654), and that the only remaining unlayered authored rule is the documented `.active-navigation` exception.

Local run: unit 78/78 · Playwright 7 passed 2 skipped · lint clean · Prettier clean · build clean.

## Note on the diff size

+304/-288 on a single file looks large for a change that does nothing. Almost all of it is indentation from the `@layer` wrap. Reviewing with whitespace hidden shows the real change is small:

```
git diff -w upstream/websiteRedesign..refactor/layer-globals-css
```

## Checklist

- [x] Tests added/updated — covered by the browser suite added in #589
- [x] Documentation updated — n/a, no API or workflow change
- [x] Linting passes
- [x] Branch up-to-date with base

## Deployment Notes

None. Verified inert.
